### PR TITLE
sketchfab processEvents() error

### DIFF
--- a/Sketchfab.py
+++ b/Sketchfab.py
@@ -248,7 +248,7 @@ class SketchfabTaskPanel:
         # for now this is a fake progress bar, it won't move, just to show the user that the upload is in progress
         self.form.ProgressBar.setFormat(translate("WebTools","Uploading")+" "+pack[1]+"...")
         self.form.ProgressBar.show()
-        QtGui.qApp.processEvents()
+        QtGui.QApplication.instance().processEvents()
         try:
             r = requests.post(SKETCHFAB_UPLOAD_URL, **self.get_request_payload(self.form.Text_Token.text(), data, files=files))
         except requests.exceptions.RequestException as e:
@@ -277,7 +277,7 @@ class SketchfabTaskPanel:
         self.form.ProgressBar.setValue(75)
         if self.poll(self.url):
             self.form.ProgressBar.setFormat(translate("WebTools","Fixing model..."))
-            QtGui.qApp.processEvents()
+            QtGui.QApplication.instance().processEvents()
             self.patch(self.url)
         else:
             QtGui.QMessageBox.warning(None,translate("WebTools","Patch error"),translate("WebTools","Patching failed. The model was successfully uploaded, but might still require manual adjustments."))


### PR DESCRIPTION
When trying up upload a model to Sketchfab I get the following error:

`Traceback (most recent call last):
  File "/home/rwoodhouse/.FreeCAD/Mod/WebTools/Sketchfab.py", line 281, in fix
    QtGui.qApp.processEvents()
AttributeError: 'NoneType' object has no attribute 'processEvents'`

Looking at: https://stackoverflow.com/questions/40400954/qapp-versus-qapplication-instance/40405396#40405396 replacing `qApp` with `QApplication.instance()` will fix the issue and is backwards compatible.

OS: elementary OS 5.0 Juno
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.18.14555 (Git shallow)
Build type: Release
Branch: master
Hash: 51b953e2c6edd7f76b1d8faa584424cfb6367d45
Python version: 3.7.1
Qt version: 5.6.2
Coin version: 4.0.0a
OCC version: 7.3.0
Locale: English/UnitedKingdom (en_GB)
