### PR TITLE
README.md: cleanup and fix URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 This workbench contains tools to interact with different web services. Current webservices include:
 
-<img src="https://raw.githubusercontent.com/yorikvanhavre/WebTools/master/icons/git.svg" width="20" height="20" alt="git logo"> [Git](https://www.freecadweb.org/wiki/Arch_Git): Manages the current document with [Git](https://en.wikipedia.org/wiki/Git).  
+<img src="./icons/git.svg" width="20" height="20" alt="git logo"> [Git](https://www.freecadweb.org/wiki/WebTools_Git): Manages the current document with [Git](https://en.wikipedia.org/wiki/Git).
 
-<img src="https://raw.githubusercontent.com/yorikvanhavre/WebTools/master/icons/bimserver.svg" width="20" height="20" alt="bimserver logo">  [BimServer](https://www.freecadweb.org/wiki/Arch_BimServer): Connects and interacts with a [BIM server](http://www.bimserver.org) instance.  
+<img src="./icons/bimserver.svg" width="20" height="20" alt="bimserver logo">  [BimServer](https://www.freecadweb.org/wiki/WebTools_BimServer): Connects and interacts with a [BIM server](https://bimserver.org) instance.  
 
-<img src="https://raw.githubusercontent.com/yorikvanhavre/WebTools/master/icons/sketchfab.svg" width="20" height="20" alt="sketchfab logo"> [Sketchfab](https://www.freecadweb.org/wiki/Web_Sketchfab): Connects and uploads a model to a [Sketchfab](http://www.sketchfab.com) account. 
+<img src="./icons/sketchfab.svg" width="20" height="20" alt="sketchfab logo"> [Sketchfab](https://www.freecadweb.org/wiki/WebTools_Sketchfab): Connects and uploads a model to a [Sketchfab](https://sketchfab.com) account. 
 
 ## Installation
 
 This Workbench is part of the [FreeCAD addons](https://github.com/FreeCAD/FreeCAD-addons) collection and can be simply installed from the Addons manager.
 
-Alternatively, it can also be installed manually by downloading and copying its contents in a folder inside your FreeCAD Mod directory (see the [addons page](https://github.com/yorikvanhavre/WebTools.git) for detailed instructions)
+Alternatively, it can also be installed manually by downloading and copying its contents in a folder inside your FreeCAD Mod directory (see the ["Manual install" section of the addons page](https://github.com/FreeCAD/FreeCAD-addons?tab=readme-ov-file#2-manual-install) for detailed instructions)


### PR DESCRIPTION
This PR cleans up and fixes various README.md URLs:

- `…freecadweb.org/wiki/Arch_…` now points to the applicable `…freecadweb.org/wiki/WebTools_…` URLs
- URLs are updated to match the destination servers' final redirect URL.
    - `http` updated to `https` (matches the destination servers)
- provides relative paths for `./icons/*.svg` markdown file references
- "… can also be installed manually …" now provides a link to the "Manual install" section of [FreeCAD-addons](https://github.com/FreeCAD/FreeCAD-addons?tab=readme-ov-file#2-manual-install)