### PR TITLE
Update BIMServer.py

### DIFF
--- a/BIMServer.py
+++ b/BIMServer.py
@@ -80,7 +80,8 @@ class BimServerTaskPanel:
         self.prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
         self.Projects = []
         self.Revisions = []
-        self.RootObjects = Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"IfcSite")+Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"IfcBuilding")
+        self.RootObjects = Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"Site")+Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"Building")
+        self.RootObjects += Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"IfcSite")+Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"IfcBuilding")
         for o in self.RootObjects:
             self.form.comboRoot.addItem(o.Label)
         self.setLogged(False)

--- a/BIMServer.py
+++ b/BIMServer.py
@@ -80,7 +80,7 @@ class BimServerTaskPanel:
         self.prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
         self.Projects = []
         self.Revisions = []
-        self.RootObjects = Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"Site")+Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"Building")
+        self.RootObjects = Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"IfcSite")+Draft.getObjectsOfType(FreeCAD.ActiveDocument.Objects,"IfcBuilding")
         for o in self.RootObjects:
             self.form.comboRoot.addItem(o.Label)
         self.setLogged(False)


### PR DESCRIPTION
WebTools BIMServer collects root objects by searching for class Site and Building. When using Ifc the correct classes are IfcSite and IfcBuilding

- changed in search for classes strings to IfcSite and IfcBuilding  

fixes #28 